### PR TITLE
make start script more cross-platform (notably NixOS)

### DIFF
--- a/start
+++ b/start
@@ -1,5 +1,7 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 # Script to start the local dev server
+
+set -e
 
 # Unless the RunDevServer binary is available, we rebuild the .envrc cache with nix-shell
 # and config cachix for using our binary cache


### PR DESCRIPTION
On different distributions, bash might be located at different points, meaning it won't always be at `/bin/bash`. To help write shebangs for all distros, `/usr/bin/env` can be used.
This is most notably necessary for NixOS support.

This PR updates the `./start` script to use `#!/usr/bin/env bash`.