### PR TITLE
add all extensions in use

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -229,3 +229,20 @@ language_extensions:
   - TemplateHaskell
   - QuasiQuotes
   - TypeApplications
+  - TypeSynonymInstances
+  - OverloadedLabels
+  - DataKinds
+  - DuplicateRecordFields
+  - FlexibleContexts
+  - FlexibleInstances
+  - RecordWildCards
+  - MultiParamTypeClasses
+  - LambdaCase
+  - BlockArguments
+  - TypeFamilies
+  - ConstraintKinds
+  - FlexibleInstances
+  - InstanceSigs
+  - StandaloneDeriving
+  - TypeOperators
+  - UndecidableInstances


### PR DESCRIPTION
This adds several extensions that are used by ihp-boilerplate (defined either in App.cabal or via language pragma's)
This change is necessitated to enabled formatting of the whole code base by stylish-haskell without any errors.