### PR TITLE
IHP Specific GHCI Config

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,4 @@
-import Prelude
+:set -XNoImplicitPrelude
 :def source readFile
 :source build/ihp-lib/applicationGhciConfig
+import IHP.Prelude


### PR DESCRIPTION
Using `IHP.Prelude` instead of base `Prelude`