### PR TITLE
Introduce Build Env Script

### DIFF
--- a/build-env
+++ b/build-env
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+nix-shell -j auto --cores 0 --run 'make -B .envrc'


### PR DESCRIPTION
There are many references to the `nix-shell -j auto --cores 0 --run 'make -B .envrc'` script in the Guide, wiki, however it's easier to remember running `./build-env` and that also gives us the flexibility to adjust this script in the future.