### PR TITLE
More robust Elm initialization

### DIFF
--- a/elm/index.js
+++ b/elm/index.js
@@ -19,7 +19,7 @@ function getFlags(data) {
 }
 
 // Initialize Elm on page load
-window.addEventListener('load', (event) => {
+window.addEventListener("load", (event) => {
   initializeWidgets();
 });
 

--- a/elm/index.js
+++ b/elm/index.js
@@ -1,7 +1,29 @@
+"use strict";
 import { Elm } from "./Main.elm";
 
-window.addEventListener('DOMContentLoaded', function () {
-  Elm.Main.init({
-    node: document.querySelector(".elm"),
+// Run Elm on all elm Nodes
+function initializeWidgets() {
+  const elmNodes = document.querySelectorAll(".elm");
+  elmNodes.forEach((node) => {
+    const app = Elm.Main.init({
+      node,
+      flags: getFlags(node.dataset.flags),
+    });
+    // Initialize ports below this line
   });
-})
+}
+
+// Parse the JSON from IHP or just pass null if there is no flags data
+function getFlags(data) {
+  return data ? JSON.parse(data) : null;
+}
+
+// Initialize Elm on page load
+window.addEventListener('load', (event) => {
+  initializeWidgets();
+});
+
+// Initialize Elm on Turbolinks transition
+document.addEventListener("turbolinks:load", (e) => {
+  initializeWidgets();
+});


### PR DESCRIPTION
After some experience of building with Elm, I have found this to be a more robust loading of Elm apps. This can load several Elm widgets at once and does work for both normal page loads and Turbolinks transitions :)

I am probably writing up a small appendix for the blog series, or I might just change the tutorial a bit.