### PR TITLE
Add more defaults an docs to flake.nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,3 +14,8 @@ fi
 # Add your env vars here
 #
 # E.g. export AWS_ACCESS_KEY_ID="XXXXX"
+
+# SMTP config for local development.
+export SMTP_HOST="127.0.0.1" # On some computers may need `127.0.1.1` instead.
+export SMTP_PORT="1025"
+export SMTP_ENCRYPTION="Unencrypted"

--- a/flake.nix
+++ b/flake.nix
@@ -20,8 +20,8 @@
                     packages = with pkgs; [
                         # Native dependencies, e.g. imagemagick
 
-                        # Used on local development to catch outgoing emails
-                        mailhog
+                        # Uncomment on local development to catch outgoing emails
+                        # mailhog
                     ];
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
@@ -31,8 +31,8 @@
                         wai
                         text
 
-                        # Package for testing
-                        hspec
+                        # Uncomment on local development for testing
+                        # hspec
                     ];
                 };
 
@@ -62,8 +62,8 @@
                     ({ lib, pkgs, ... }: {
 
                         networking.firewall = {
-                           enable = true;
-                           allowedTCPPorts = [ 22 80 443 8000 ];
+                            enable = true;
+                            allowedTCPPorts = [ 22 80 443 8000 ];
                         };
 
                         # Enable the Let's encrypt certificate
@@ -73,10 +73,10 @@
                         security.acme.acceptTerms = true;
 
                         services.nginx = {
-                          virtualHosts."CHANGE-ME.com" =  {
-                            # Uncomment to have http auth with username `foo` and password `bar`.
-                            # basicAuth = { foo = "bar"; };
-                          };
+                            virtualHosts."CHANGE-ME.com" =  {
+                                # Uncomment to have http auth with username `foo` and password `bar`.
+                                # basicAuth = { foo = "bar"; };
+                            };
                         };
 
                         services.ihp = {
@@ -88,18 +88,19 @@
                             additionalEnvVars = {
                                 # Uncomment to use a custom database URL
                                 # DATABASE_URL = "postgresql://postgres:...CHANGE-ME";
+
                                 SMTP_HOST = "email-smtp.eu-west-1.amazonaws.com";
                                 SMTP_PORT = "587";
                                 SMTP_USER = "CHANGE-ME";
                                 SMTP_PASSWORD = "CHANGE-ME";
+
                                 # Indicate the environment name, e.g. "production", "staging", "qa".
                                 ENV_NAME = "qa";
+
                                 AWS_ACCESS_KEY_ID = "CHANGE-ME";
                                 AWS_SECRET_ACCESS_KEY = "CHANGE-ME";
                             };
                         };
-
-                        swapDevices = [ { device = "/swapfile"; size = 3000; } ];
 
                         # Keep as is.
                         system.stateVersion = "23.05";

--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,6 @@
                     projectPath = ./.;
                     packages = with pkgs; [
                         # Native dependencies, e.g. imagemagick
-
-                        # Uncomment on local development to catch outgoing emails
-                        # mailhog
                     ];
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here
@@ -38,7 +35,7 @@
 
                 # Custom configuration that will start with `devenv up`
                 devenv.shells.default = {
-                    # Start Mailhog
+                    # Start Mailhog on local development to catch outgoing emails
                     services.mailhog.enable = true;
 
                     # Custom processes that don't appear in https://devenv.sh/reference/options/

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             };
 
             # Adding the new NixOS configuration for "qa"
+            # See https://ihp.digitallyinduced.com/Guide/deployment.html#deploying-with-deploytonixos for more info
             # Used to deploy the IHP application to AWS.
             #
             # Change the `CHANGE-ME` to your correct config.
@@ -101,7 +102,7 @@
                         # it is essential to enable automatic updates.
                         # @see https://nixos.wiki/wiki/Automatic_system_upgrades
                         system.autoUpgrade.enable = true;
-                        # Keep as is.
+                        # Keep as is. See https://nixos.wiki/wiki/FAQ/When_do_I_update_stateVersion
                         system.stateVersion = "23.05";
                     })
                 ];

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,10 @@
                                 AWS_SECRET_ACCESS_KEY = "CHANGE-ME";
                             };
                         };
-
+                        # As we use a pre-built AMI on AWS,
+                        # it is essential to enable automatic updates.
+                        # @see https://nixos.wiki/wiki/Automatic_system_upgrades
+                        system.autoUpgrade.enable = true;
                         # Keep as is.
                         system.stateVersion = "23.05";
                     })

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
                 # Custom configuration that will start with `devenv up`
                 devenv.shells.default = {
                     # Start Mailhog on local development to catch outgoing emails
-                    services.mailhog.enable = true;
+                    # services.mailhog.enable = true;
 
                     # Custom processes that don't appear in https://devenv.sh/reference/options/
                     processes = {
@@ -60,7 +60,7 @@
 
                         networking.firewall = {
                             enable = true;
-                            allowedTCPPorts = [ 22 80 443 8000 ];
+                            allowedTCPPorts = [ 22 80 443 ];
                         };
 
                         # Enable the Let's encrypt certificate

--- a/flake.nix
+++ b/flake.nix
@@ -83,6 +83,9 @@
                             fixtures = ./Application/Fixtures.sql;
                             sessionSecret = "CHANGE-ME";
                             additionalEnvVars = {
+                                # Indicate the environment name, e.g. "production", "staging", "qa".
+                                ENV_NAME = "qa";
+
                                 # Uncomment to use a custom database URL
                                 # DATABASE_URL = "postgresql://postgres:...CHANGE-ME";
 
@@ -92,9 +95,6 @@
 
                                 SMTP_USER = "CHANGE-ME";
                                 SMTP_PASSWORD = "CHANGE-ME";
-
-                                # Indicate the environment name, e.g. "production", "staging", "qa".
-                                ENV_NAME = "qa";
 
                                 AWS_ACCESS_KEY_ID = "CHANGE-ME";
                                 AWS_SECRET_ACCESS_KEY = "CHANGE-ME";

--- a/flake.nix
+++ b/flake.nix
@@ -49,11 +49,11 @@
                 };
             };
 
-            # Adding the new NixOS configuration for "ihp-app"
+            # Adding the new NixOS configuration for "qa"
             # Used to deploy the IHP application to AWS.
             #
             # Change the `CHANGE-ME` to your correct config.
-            flake.nixosConfigurations."ihp-app" = nixpkgs.lib.nixosSystem {
+            flake.nixosConfigurations."qa" = nixpkgs.lib.nixosSystem {
                 system = "x86_64-linux";
                 specialArgs = inputs;
                 modules = [

--- a/flake.nix
+++ b/flake.nix
@@ -83,9 +83,6 @@
                             fixtures = ./Application/Fixtures.sql;
                             sessionSecret = "CHANGE-ME";
                             additionalEnvVars = {
-                                # Indicate the environment name, e.g. "production", "staging", "qa".
-                                ENV_NAME = "qa";
-
                                 # Uncomment to use a custom database URL
                                 # DATABASE_URL = "postgresql://postgres:...CHANGE-ME";
 

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,8 @@
 
                                 SMTP_HOST = "email-smtp.eu-west-1.amazonaws.com";
                                 SMTP_PORT = "587";
+                                SMTP_ENCRYPTION = "STARTTLS";
+
                                 SMTP_USER = "CHANGE-ME";
                                 SMTP_PASSWORD = "CHANGE-ME";
 


### PR DESCRIPTION
First stab at providing more defaults and docs inside the flake.nix so it's easier to deploy

Some things I didn't know:

1. How to allow Mailhog and hspec only for local, and make sure they are not deployed?
2. Here I define a `qa` env. Is it possible to define multiple envs?