### PR TITLE
Disk space issue workaround

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,12 @@ jobs:
 
     - name: Run project and tests
       run: |
+          # @see https://github.com/actions/runner-images/issues/2840#issuecomment-1284059930
+          # IHP - NixOS requires a lots of disk space.
+          # Larger projects could easily run into unexpected failures.
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
           # Build generated files.
           nix-shell --run "make build/Generated/Types.hs"
 


### PR DESCRIPTION
Sometimes it takes too much disk space to compile / provision the project inside a GH Runner.