### PR TITLE
Install node and npm from nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
                     projectPath = ./.;
                     packages = with pkgs; [
                         # Native dependencies, e.g. imagemagick
+                        nodejs # elm support needs node npm
                     ];
                     haskellPackages = p: with p; [
                         # Haskell dependencies go here


### PR DESCRIPTION
This is follow up to #40 . It adds nodejs (and hence npm) to devenv packages to not rely on these to be installed locally.

Auto run of `npm install`. I  watend to run it via `enterShell` but then realized that npm install is run as part of ihp-script (see [end of the line here](https://github.com/digitallyinduced/ihp/blob/master/ProjectGenerator/bin/ihp-new#L255)) so it is not necessary.