### PR TITLE
Don't use nix-shell on GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,13 +50,13 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
           # Build generated files.
-          nix-shell --run "make build/Generated/Types.hs"
+          make build/Generated/Types.hs
 
           # Start the project in the background.
-          nix-shell --run "devenv up &"
+          devenv up &
 
           # Execute the tests.
-          nix-shell --run "runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs"
+          runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
 
   deploy:
     name: Deploy


### PR DESCRIPTION
Prevent getting an error:

```
Detected Bash version that isn't supported by Nixpkgs (4.4.23(1)-release)
Please install Bash 5 or greater to continue.
```