### PR TITLE
On GH action test, wait for the IHP server to start.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,21 @@ jobs:
           # Start the project in the background.
           devenv up &
 
+          # Wait for the IHP server to start.
+          timeout=60
+          while [ $timeout -gt 0 ]; do
+            if curl -s http://localhost:8000 >/dev/null 2>&1; then
+              echo "IHP server is ready!"
+              break
+            fi
+            sleep 1
+            timeout=$((timeout - 1))
+          done
+          if [ $timeout -eq 0 ]; then
+            echo "Timeout waiting for IHP server to start"
+            exit 1
+          fi
+
           # Execute the tests.
           runghc $(make print-ghc-extensions) -i. -ibuild -iConfig Test/Main.hs
 


### PR DESCRIPTION
Tests should be executed only after the `devenv up` is done compiling, and server is ready to get requests