### PR TITLE
Use separate nixpkgs-nixos for NixOS deployments

### DIFF
--- a/Config/nix/hosts/production/host.nix
+++ b/Config/nix/hosts/production/host.nix
@@ -1,6 +1,6 @@
 { inputs }:
-inputs.nixpkgs.lib.nixosSystem {
+inputs.nixpkgs-nixos.lib.nixosSystem {
     system = "x86_64-linux"; # or alternatively: aarch64-linux
-    specialArgs = inputs;
+    specialArgs = inputs // { nixpkgs = inputs.nixpkgs-nixos; };
     modules = [ ./configuration.nix ];
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
     inputs = {
         ihp.url = "github:digitallyinduced/ihp/v1.4";
         nixpkgs.follows = "ihp/nixpkgs";
+        nixpkgs-nixos.follows = "ihp/nixpkgs-nixos";
         flake-parts.follows = "ihp/flake-parts";
         devenv.follows = "ihp/devenv";
         systems.follows = "ihp/systems";
@@ -11,7 +12,7 @@
         };
     };
 
-    outputs = inputs@{ self, nixpkgs, ihp, flake-parts, systems, ... }:
+    outputs = inputs@{ self, nixpkgs, nixpkgs-nixos, ihp, flake-parts, systems, ... }:
         flake-parts.lib.mkFlake { inherit inputs; } {
 
             systems = import systems;


### PR DESCRIPTION
## Summary
- Add `nixpkgs-nixos.follows = "ihp/nixpkgs-nixos"` flake input for NixOS server deployments
- Update `host.nix` to use `nixpkgs-nixos` for `nixosSystem` evaluation, keeping app binaries built against the Haskell nixpkgs

Depends on https://github.com/digitallyinduced/ihp/pull/2519.

## Test plan
- [ ] Merge IHP PR first, then update `ihp.url` to verify `nix flake metadata` resolves both inputs
- [ ] `nix flake check --impure` passes after IHP PR is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)