### PR TITLE
[codex] Document local lib directory

### DIFF
--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,35 @@
+# Local Haskell Libraries
+
+Put local Cabal packages in this directory when code should live outside the IHP application but stay in the same repository.
+
+Typical structure:
+
+```text
+lib/
+`-- my-client/
+    |-- default.nix
+    |-- my-client.cabal
+    `-- src/
+        `-- MyClient.hs
+```
+
+Generate `default.nix` inside the package directory and commit it:
+
+```bash
+cd lib/my-client
+nix run nixpkgs#cabal2nix -- . > default.nix
+```
+
+Then add the package to `haskellPackages` in `flake.nix`:
+
+```nix
+haskellPackages = p: with p; [
+    p.ihp
+    base
+    wai
+    text
+    (p.callPackage ./lib/my-client {})
+];
+```
+
+IHP ignores this top-level `lib/` directory when scanning application modules, so local libraries are compiled through their own Cabal packages.

--- a/lib/README.md
+++ b/lib/README.md
@@ -33,3 +33,23 @@ haskellPackages = p: with p; [
 ```
 
 IHP ignores this top-level `lib/` directory when scanning application modules, so local libraries are compiled through their own Cabal packages.
+
+When a local package is reused by multiple applications or needs its own CI, move it into a separate GitHub repository. Keep the generated `default.nix`, add a small `flake.nix` to the package repository, and consume it from the IHP app as a flake input:
+
+```nix
+inputs.my-client.url = "github:my-org/my-client";
+```
+
+Then compile it with the app's Haskell package set:
+
+```nix
+haskellPackages = p: with p; [
+    p.ihp
+    base
+    wai
+    text
+    (p.callPackage (my-client + "/default.nix") {})
+];
+```
+
+This keeps the dependency pinned through `flake.lock` while avoiding a separate GHC/package set for the library.


### PR DESCRIPTION
## Summary
- Add `lib/README.md` to the boilerplate.
- Explain that local Cabal packages can live under `lib/`.
- Show the checked-in `default.nix` plus `callPackage` workflow.
- Mention when to move a library to its own GitHub repo and how to consume it as a pinned flake input while compiling with the IHP app package set.

## Why
This gives new IHP projects a documented place for in-repo Haskell libraries such as API clients or shared domain packages, plus a path for splitting reusable packages out later.

## Validation
- `git diff --check`
- `nix-instantiate --parse` for the external-library flake snippet and consuming-app snippet in the IHP docs PR.
- `nix flake check` currently fails on the existing devenv assertion: `devenv was not able to determine the current directory`.