### PR TITLE
Add self-hosted binary cache alongside cachix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,12 +96,14 @@
             "https://devenv.cachix.org"
             "https://cachix.cachix.org"
             "https://digitallyinduced.cachix.org"
+            "https://cache.digitallyinduced.com/public"
             # "https://CHANGE-ME.cachix.org"
         ];
         extra-trusted-public-keys = [
             "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
             "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
             "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE="
+            "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
             # "CHANGE-ME.cachix.org-1:CHANGE-ME-PUBLIC-KEY"
         ];
     };

--- a/flake.nix
+++ b/flake.nix
@@ -95,14 +95,12 @@
         extra-substituters = [
             "https://devenv.cachix.org"
             "https://cachix.cachix.org"
-            "https://digitallyinduced.cachix.org"
             "https://cache.digitallyinduced.com/public"
             # "https://CHANGE-ME.cachix.org"
         ];
         extra-trusted-public-keys = [
             "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
             "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
-            "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE="
             "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
             # "CHANGE-ME.cachix.org-1:CHANGE-ME-PUBLIC-KEY"
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -95,12 +95,14 @@
         extra-substituters = [
             "https://devenv.cachix.org"
             "https://cachix.cachix.org"
+            "https://digitallyinduced.cachix.org"
             "https://cache.digitallyinduced.com/public"
             # "https://CHANGE-ME.cachix.org"
         ];
         extra-trusted-public-keys = [
             "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
             "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
+            "digitallyinduced.cachix.org-1:y+wQvrnxQ+PdEsCt91rmvv39qRCYzEgGQaldK26hCKE="
             "public:kR6JCoqAIMaO4s+EdDGh+jsHEHnoLq4ZLJPMCo0hcIQ="
             # "CHANGE-ME.cachix.org-1:CHANGE-ME-PUBLIC-KEY"
         ];


### PR DESCRIPTION
Adds the self-hosted Attic cache `https://cache.digitallyinduced.com/public` (public, no token) to the boilerplate `nixConfig`, alongside the existing cachix substituters. New IHP projects will pull prebuilt IHP artifacts from it.

Coverage: x86_64-linux + aarch64-darwin (populated by IHP CI — see digitallyinduced/ihp#2700).

🤖 Generated with [Claude Code](https://claude.com/claude-code)