### PR TITLE
Add .claude/launch.json for Claude Code desktop Preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "IHP App",
+      "runtimeExecutable": "devenv",
+      "runtimeArgs": ["up"],
+      "port": 8000
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "IHP App",
       "runtimeExecutable": "devenv",
       "runtimeArgs": ["up"],
-      "port": 8000
+      "port": 8000,
+      "autoPort": true
     }
   ]
 }


### PR DESCRIPTION
## What

Adds `.claude/launch.json` to the boilerplate so Claude Code desktop's **Preview** feature works out-of-the-box for every new IHP project.

```json
{
  "version": "0.0.1",
  "configurations": [
    { "name": "IHP App", "runtimeExecutable": "devenv", "runtimeArgs": ["up"], "port": 8000 }
  ]
}
```

## Why

`.claude/launch.json` is the config Claude Code desktop's Preview feature reads to start a project's dev server. Without it, the desktop app has to guess how to launch the app. This wires it to IHP's canonical launch command.

- `devenv up` is how IHP apps start — it's exactly what the existing `start` script runs and what `ihp-new` prints as the start command.
- Port `8000` is IHP's default app port (`defaultPort = 8000`); the IHP IDE tool server is on 8001.

## Propagation

`ihp-new` creates projects via a plain `git clone` of this boilerplate followed by `git add .` (no file filtering), so this committed file lands verbatim in every generated project automatically.

## Notes

- This is unrelated to VS Code's `.vscode/launch.json` (debugger config) — different file, different consumer.
- For consistency, the same file could later be merged into the `elm` and `purescript-halogen` branches (also cloned by `ihp-new`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)