### PR TITLE
Run CI on master; fix stale README and pre-existing production deploy config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "IHP App",
+      "runtimeExecutable": "devenv",
+      "runtimeArgs": ["up"],
+      "port": 8000
+    }
+  ]
+}

--- a/.github/workflows/nix-flake-check.yml
+++ b/.github/workflows/nix-flake-check.yml
@@ -1,9 +1,9 @@
 name: Test
 on:
   push:
-    branches: [main]
+    branches: [master, main]
   pull_request:
-    branches: [main]
+    branches: [master, main]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Config/nix/hosts/production/configuration.nix
+++ b/Config/nix/hosts/production/configuration.nix
@@ -64,9 +64,11 @@
 
     services.ihp = {
         domain = "CHANGE-ME.com";
-        migrations = ./Application/Migration;
-        schema = ./Application/Schema.sql;
-        fixtures = ./Application/Fixtures.sql;
+        # Paths are relative to this file (Config/nix/hosts/production/), so reach
+        # back up to the project root where the Application/ directory lives.
+        migrations = ../../../../Application/Migration;
+        schema = ../../../../Application/Schema.sql;
+        fixtures = ../../../../Application/Fixtures.sql;
         sessionSecret = "CHANGE-ME";
         # Uncomment to use a custom database URL
         # databaseUrl = lib.mkForce "postgresql://postgres:...CHANGE-ME";

--- a/Config/nix/hosts/production/configuration.nix
+++ b/Config/nix/hosts/production/configuration.nix
@@ -11,6 +11,11 @@
         ihp.nixosModules.appWithPostgres
     ];
 
+    # The IHP module sets `programs.vim.defaultEditor = true`, but nixpkgs 25.05
+    # asserts that this requires `programs.vim.enable = true`. We don't need vim
+    # for deployment, so disable the default-editor setting to satisfy the assertion.
+    programs.vim.defaultEditor = lib.mkForce false;
+
     networking.firewall = {
         enable = true;
         allowedTCPPorts = [ 22 80 443 ];

--- a/README.md
+++ b/README.md
@@ -1,68 +1,40 @@
 # IHP Project
 
-This is an IHP (Integrated Haskell Platform) project with GitHub Actions for testing and deployment. For more information about IHP, see the [IHP Documentation](https://ihp.digitallyinduced.com/Guide/).
+This is an IHP (Integrated Haskell Platform) project with a GitHub Actions workflow for continuous integration. For more information about IHP, see the [IHP Documentation](https://ihp.digitallyinduced.com/Guide/).
 
 ## GitHub Actions Workflow
 
-This project includes a GitHub Actions workflow for automated testing and deployment. The workflow is defined in `.github/workflows/test.yml`.
+This project includes a GitHub Actions workflow that builds the project and runs its test suite via `nix flake check`. The workflow is defined in [`.github/workflows/nix-flake-check.yml`](.github/workflows/nix-flake-check.yml).
 
 ### Workflow Triggers
 
-The workflow is triggered on:
-- Push to the `main` branch
-- Pull requests to the `main` branch
-- Manual trigger from the GitHub Actions tab
+The `Test` workflow runs on:
+- Push to the `master` (or `main`) branch
+- Pull requests targeting the `master` (or `main`) branch
 
-### Testing
+Both branch names are listed so the workflow works whether the default branch is `master` (as in this repository) or `main` (the default for new repositories created from this boilerplate).
 
-The testing job performs the following steps:
+### What the workflow does
+
+The `test` job runs on `ubuntu-latest` and performs the following steps:
 1. Checks out the code
-2. Sets up Nix
-3. Initializes Cachix for faster builds
-4. Installs and allows direnv
-5. Builds generated files
-6. Starts the project in the background
-7. Runs the tests
+2. Frees up disk space for large Nix builds ([nothing-but-nix](https://github.com/wimpysworld/nothing-but-nix))
+3. Installs Nix using the [Determinate Nix installer](https://github.com/DeterminateSystems/nix-installer-action) with lazy trees enabled
+4. Configures the [`digitallyinduced` Cachix cache](https://app.cachix.org/cache/digitallyinduced) for faster builds (pull only — `skipPush: true`)
+5. Enables the [Magic Nix Cache](https://github.com/DeterminateSystems/magic-nix-cache-action)
+6. Runs `nix flake check --impure -L`, which builds the project and runs the test suite
 
-### Deployment
+## Running the checks locally
 
-For deployment, follow the [IHP Deployment Guide](https://ihp.digitallyinduced.com/Guide/deployment.html#deploying-with-deploytonixos) to set up a proper NixOS server for your project.
+You can run the same checks that CI runs:
 
-The deployment job runs after successful tests and only for the `main` branch. It performs the following steps:
-1. Checks out the code
-2. Sets up SSH for deployment
-3. Sets up Nix
-4. Initializes Cachix
-5. Sets up direnv
-6. Deploys to a NixOS server
+```bash
+nix flake check --impure
+```
 
-## Setup Instructions
+## Deployment
 
-To use the GitHub Actions workflow in this project:
-
-1. Set up the following secrets in your GitHub [repository settings](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions):
-   - `SSH_HOST`: The hostname or IP address of your deployment server
-   - `SSH_USER`: The username for SSH access to the deployment server
-   - `SSH_PRIVATE_KEY`: The private SSH key for authentication
-
-2. Modify the `env` section in `.github/workflows/test.yml` if needed:
-   - Update `PROJECT_NAME` to match your project
-   - Adjust `ENV` if you want to use a different environment name
-   - Update `NIXPKGS` if you want to use a different Nixpkgs version
-
-3. Ensure your project has the necessary test files in the `Test` directory.
-
-4. If your deployment process differs, modify the `deploy` job in the workflow file accordingly.
-
-5. Push your changes to the `main` branch to trigger the workflow.
-
-## Manual Workflow Trigger
-
-You can manually trigger the workflow from the Actions tab in your GitHub repository. This is useful for running tests or deploying without pushing changes.
-
-## Customization
-
-Feel free to customize the workflow file to fit your specific project needs. You may want to add additional steps, change the deployment process, or modify the testing procedure.
+This boilerplate does not include an automated deployment job. To deploy your project, follow the [IHP Deployment Guide](https://ihp.digitallyinduced.com/Guide/deployment.html#deploying-with-deploytonixos) to set up a NixOS server.
 
 ## Support
 


### PR DESCRIPTION
## Problem

The `nix-flake-check.yml` workflow only triggered on `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

But the default branch is `master`, and no `main` branch exists — so the `Test` workflow **never ran** on `master` pushes or PRs (e.g. [#67](https://github.com/digitallyinduced/ihp-boilerplate/pull/67) got zero runs). `[main]` was the stock GitHub Actions template default, never adjusted.

## Changes

### 1. CI triggers — `.github/workflows/nix-flake-check.yml`
Trigger on `[master, main]` for both `push` and `pull_request`. `master` is the current default branch; `main` is included so CI also works for projects generated from this boilerplate (where `main` is GitHub's default) and survives a future rename. Listing `main` costs nothing since it doesn't exist here yet.

### 2. README — `README.md`
Was entirely stale: it described a non-existent `.github/workflows/test.yml` with a deploy job, SSH secrets (`SSH_HOST`/`SSH_USER`/`SSH_PRIVATE_KEY`), and `PROJECT_NAME`/`ENV`/`NIXPKGS` env vars — none of which exist. Rewritten to document the single `nix-flake-check.yml` workflow that actually exists.

### 3. Pre-existing production-config bugs (surfaced by newly-enabled CI)

Once CI actually ran, `nix flake check` revealed that `nixosConfigurations.production` had **never evaluated cleanly** — it was never tested because CI never ran. Two latent bugs, both fixed here:

- **`programs.vim.defaultEditor` assertion** — the IHP `appWithPostgres` module sets `programs.vim.defaultEditor = true`; nixpkgs 25.05 asserts this requires `programs.vim.enable = true`. Vim isn't needed for deployment, so we `lib.mkForce false` the setting. (Mirrors the fix in the now-stale [#55](https://github.com/digitallyinduced/ihp-boilerplate/pull/55), which targets the deleted `test.yml` and can't land as-is.)
- **Broken `Application/*` paths** — `services.ihp.{schema,fixtures,migrations}` used `./Application/*`, which was correct when this config lived inline in `flake.nix` (repo root) but broke when it was moved to `Config/nix/hosts/production/` (commit `ae06da9`) without updating the relative paths. Corrected to `../../../../Application/*`. Also added the conventional `Application/Migration/` directory so the (non-null) `migrations` path resolves and deploy-time auto-migrate stays wired up.

## Verification

- **CI now triggers**: opening this PR produced workflow runs (previously: zero). ✅
- **Production config now evaluates**: `nix eval .#nixosConfigurations.production.config.system.build.toplevel.drvPath` succeeds locally (previously errored on the missing `Schema.sql` path). ✅
- Full `nix flake check` build running on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)